### PR TITLE
Add pull request workflow for testing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,8 +10,6 @@ on:
     branches: [ "main" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ "main" ]
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,49 @@
+﻿name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    tags: [ 'v*.*.*' ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      # Setup .NET SDK
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+      
+      # Restore, build, and test the .NET project
+      - name: Restore dependencies
+        working-directory: "./src"
+        run: dotnet restore
+      - name: Build
+        working-directory: "./src"
+        run: dotnet build --no-restore
+      - name: Test
+        working-directory: "./src"
+        run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
This pull request updates the CI workflows to improve Docker build and test automation for pull requests targeting the `main` branch. The changes include removing the pull request trigger from the Docker publish workflow and introducing a new workflow dedicated to building and testing .NET projects on pull requests.

**Workflow management improvements:**

* Removed the `pull_request` trigger from `.github/workflows/docker-publish.yml`, so Docker publishing will no longer run on pull requests to `main`.
* Added a new workflow `.github/workflows/pull-request.yml` that builds and tests the .NET project when a pull request targets `main` or matches a version tag pattern. This workflow sets up the environment, checks out code, restores dependencies, builds, and runs tests